### PR TITLE
Indent code in continue mode

### DIFF
--- a/liner.go
+++ b/liner.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"strings"
+	"text/scanner"
 
 	"github.com/peterh/liner"
 )
@@ -10,11 +13,13 @@ import (
 const (
 	promptDefault  = "gore> "
 	promptContinue = "..... "
+	indent         = "    "
 )
 
 type contLiner struct {
 	*liner.State
 	buffer string
+	depth  int
 }
 
 func newContLiner() *contLiner {
@@ -24,7 +29,11 @@ func newContLiner() *contLiner {
 
 func (cl *contLiner) promptString() string {
 	if cl.buffer != "" {
-		return promptContinue
+		prompt := promptContinue
+		for i := 0; i < cl.depth; i++ {
+			prompt += indent
+		}
+		return prompt
 	}
 
 	return promptDefault
@@ -53,4 +62,55 @@ func (cl *contLiner) Prompt() (string, error) {
 func (cl *contLiner) Accepted() {
 	cl.State.AppendHistory(cl.buffer)
 	cl.buffer = ""
+}
+
+func (cl *contLiner) Reindent() {
+	var min, max int
+	newDepth := cl.countDepth()
+
+	if newDepth > cl.depth {
+		min, max = cl.depth, newDepth
+	} else {
+		min, max = newDepth, cl.depth
+	}
+
+	lines := strings.Split(cl.buffer, "\n")
+	lastLine := lines[len(lines)-1]
+
+	prompt := promptDefault
+	if len(lines) > 1 {
+		prompt = promptContinue
+	}
+	fmt.Printf("\x1b[1A\r%s", prompt)
+
+	cl.printIndent(min)
+	fmt.Print(lastLine)
+	cl.printIndent(max - min)
+	fmt.Print("\n")
+
+	cl.depth = newDepth
+}
+
+func (cl *contLiner) countDepth() int {
+	reader := bytes.NewBufferString(cl.buffer)
+	sc := new(scanner.Scanner)
+	sc.Init(reader)
+
+	depth := 0
+	for {
+		switch sc.Scan() {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		case scanner.EOF:
+			return depth
+		}
+	}
+}
+
+func (cl *contLiner) printIndent(count int) {
+	for i := 0; i < count; i++ {
+		fmt.Print(indent)
+	}
 }

--- a/liner.go
+++ b/liner.go
@@ -77,11 +77,12 @@ func (cl *contLiner) Reindent() {
 	lines := strings.Split(cl.buffer, "\n")
 	lastLine := lines[len(lines)-1]
 
-	prompt := promptDefault
+	cursorUp()
 	if len(lines) > 1 {
-		prompt = promptContinue
+		fmt.Printf("\r%s", promptContinue)
+	} else {
+		fmt.Printf("\r%s", promptDefault)
 	}
-	fmt.Printf("\x1b[1A\r%s", prompt)
 
 	cl.printIndent(min)
 	fmt.Print(lastLine)

--- a/liner.go
+++ b/liner.go
@@ -65,13 +65,13 @@ func (cl *contLiner) Accepted() {
 }
 
 func (cl *contLiner) Reindent() {
-	var min, max int
+	var minDepth int
 	newDepth := cl.countDepth()
 
 	if newDepth > cl.depth {
-		min, max = cl.depth, newDepth
+		minDepth = cl.depth
 	} else {
-		min, max = newDepth, cl.depth
+		minDepth = newDepth
 	}
 
 	lines := strings.Split(cl.buffer, "\n")
@@ -84,9 +84,9 @@ func (cl *contLiner) Reindent() {
 		fmt.Printf("\r%s", promptDefault)
 	}
 
-	cl.printIndent(min)
+	cl.printIndent(minDepth)
 	fmt.Print(lastLine)
-	cl.printIndent(max - min)
+	eraseInLine()
 	fmt.Print("\n")
 
 	cl.depth = newDepth

--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func main() {
 			continue
 		}
 
+		rl.Reindent()
 		err = s.Eval(in)
 		if err != nil {
 			if err == ErrContinue {

--- a/terminal_unix.go
+++ b/terminal_unix.go
@@ -9,3 +9,7 @@ import (
 func cursorUp() {
 	fmt.Print("\x1b[1A")
 }
+
+func eraseInLine() {
+	fmt.Print("\x1b[0K")
+}

--- a/terminal_unix.go
+++ b/terminal_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+)
+
+func cursorUp() {
+	fmt.Print("\x1b[1A")
+}

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -33,6 +33,7 @@ var (
 	procGetStdHandle               = kernel32.NewProc("GetStdHandle")
 	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
 	procSetConsoleCursorPosition   = kernel32.NewProc("SetConsoleCursorPosition")
+	procFillConsoleOutputCharacter = kernel32.NewProc("FillConsoleOutputCharacterW")
 
 	stdoutHandle uintptr
 )
@@ -55,4 +56,12 @@ func cursorUp() {
 	cursor.y = csbi.cursorPosition.y - 1
 
 	procSetConsoleCursorPosition.Call(stdoutHandle, uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+}
+
+func eraseInLine() {
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(stdoutHandle, uintptr(unsafe.Pointer(&csbi)))
+
+	var w uint32
+	procFillConsoleOutputCharacter.Call(stdoutHandle, uintptr(' '), uintptr(csbi.size.x), uintptr(*(*int32)(unsafe.Pointer(&csbi.cursorPosition))), uintptr(unsafe.Pointer(&w)))
 }

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type short int16
+type word uint16
+
+type coord struct {
+	x short
+	y short
+}
+
+type smallRect struct {
+	left   short
+	top    short
+	right  short
+	bottom short
+}
+
+type consoleScreenBufferInfo struct {
+	size              coord
+	cursorPosition    coord
+	attributes        word
+	window            smallRect
+	maximumWindowSize coord
+}
+
+var (
+	kernel32                       = syscall.NewLazyDLL("kernel32.dll")
+	procGetStdHandle               = kernel32.NewProc("GetStdHandle")
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+	procSetConsoleCursorPosition   = kernel32.NewProc("SetConsoleCursorPosition")
+
+	stdoutHandle uintptr
+)
+
+func init() {
+	stdoutHandle = getStdHandle(syscall.STD_OUTPUT_HANDLE)
+}
+
+func getStdHandle(stdhandle int32) uintptr {
+	handle, _, _ := procGetStdHandle.Call(uintptr(stdhandle))
+	return handle
+}
+
+func cursorUp() {
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(stdoutHandle, uintptr(unsafe.Pointer(&csbi)))
+
+	var cursor coord
+	cursor.x = csbi.cursorPosition.x
+	cursor.y = csbi.cursorPosition.y - 1
+
+	procSetConsoleCursorPosition.Call(stdoutHandle, uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+}


### PR DESCRIPTION
I implemented a feature to indent continuing code using text/scanner.
It increases the indent depth by '{' token, and decreases it by '}' token.

![](http://i.gyazo.com/0bd6a05f06633ef053bd479fe217dc55.gif)