### PR TITLE
Import packages from external golang source code

### DIFF
--- a/quickfix.go
+++ b/quickfix.go
@@ -16,13 +16,17 @@ var (
 
 // doQuickFix tries to fix the source AST so that it compiles well.
 func (s *Session) doQuickFix() error {
-	const maxAttempts = 10
+	const maxAttempts = 100
 
 	for i := 0; i < maxAttempts; i++ {
 		s.TypeInfo = types.Info{
 			Types: make(map[ast.Expr]types.TypeAndValue),
 		}
-		_, err := s.Types.Check("_quickfix", s.Fset, []*ast.File{s.File}, &s.TypeInfo)
+
+		files := s.IncludeFiles
+		files = append(files, s.File)
+
+		_, err := s.Types.Check("_quickfix", s.Fset, files, &s.TypeInfo)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
I want to import package from external golang source. 
This pull request enables that by `-include` option. 

```bash
$ cd $GOPATH/src/github.com/motemen/gore
$ gore -include main.go
gore version 0.0.0  :help for help
gore> homedir.Dir()
"/Users/tcnksm"
nil
gore>
```

I'm not sure implicit vs. explicit import  (cf. https://github.com/motemen/gore/pull/2)
But for me, session should be what I expected like ruby's `irb`. 

This is just proposal. 