### PR TITLE
Support auto-importing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,6 +24,7 @@ To quit the session, type `Ctrl-D`.
 * Code completion (requires https://github.com/nsf/gocode[gocode])
 * Pretty printing (https://github.com/k0kubun/pp[pp] or https://github.com/davecgh/go-spew[spew] recommended)
 * Showing documents (requires https://golang.org/x/tools/cmd/godoc[godoc])
+* Auto-importing
 
 == REPL Commands
 
@@ -59,7 +60,6 @@ Also recommended:
 * :write completion
 * Direct editing of code
 * Using external sources
-* Auto-importing
 * API
 
 == License

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -43,7 +44,11 @@ import (
 const version = "0.0.0"
 const printerName = "__gore_p"
 
+var flagAutoImport = flag.Bool("autoimport", false, "formats and adjusts imports automatically")
+
 func main() {
+	flag.Parse()
+
 	s, err := NewSession()
 	if err != nil {
 		panic(err)
@@ -388,7 +393,9 @@ func (s *Session) Eval(in string) error {
 		}
 	}
 
-	s.fixImports()
+	if *flagAutoImport {
+		s.fixImports()
+	}
 	s.doQuickFix()
 
 	err := s.Run()

--- a/session_test.go
+++ b/session_test.go
@@ -37,3 +37,17 @@ func TestRun_QuickFix_evaluated_but_not_used(t *testing.T) {
 		noError(t, err)
 	}
 }
+
+func TestRun_FixImports(t *testing.T) {
+	s, err := NewSession()
+	noError(t, err)
+
+	codes := []string{
+		`filepath.Join("a", "b")`,
+	}
+
+	for _, code := range codes {
+		err := s.Eval(code)
+		noError(t, err)
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -42,6 +42,9 @@ func TestRun_FixImports(t *testing.T) {
 	s, err := NewSession()
 	noError(t, err)
 
+	autoimport := true
+	flagAutoImport = &autoimport
+
 	codes := []string{
 		`filepath.Join("a", "b")`,
 	}


### PR DESCRIPTION
This PR provides `auto-importing` to gore by using [golang.org/x/tools/imports](https://godoc.org/golang.org/x/tools/imports) package.
The package adds or removes import statements as necessary.

It works like the following:

```
gore version 0.0.0  :help for help
gore> filepath.Join("a", "b")
"a/b"
gore> strings.TrimPrefix("ab", "a")
"b"
gore> :print
package main

import (
    "fmt"
    "path/filepath"
    "strings"
)

func __gore_p(xx ...interface{}) {
    for _, x := range xx {
        fmt.Printf("%#v\n", x)
    }
}
func main() {
    filepath.Join("a", "b")
    strings.TrimPrefix("ab", "a")
}

```

`gore` is a very good tool.  Thank you :)