### PR TITLE
Fix for newer interface

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -243,7 +243,7 @@ func actionDoc(s *Session, in string) error {
 	} else if ident, ok := expr.(*ast.Ident); ok {
 		// package name
 		mainScope := s.TypeInfo.Scopes[s.mainFunc().Type]
-		_, docObj = mainScope.LookupParent(ident.Name)
+		_, docObj = mainScope.LookupParent(ident.Name, ident.NamePos)
 	}
 
 	if docObj == nil {


### PR DESCRIPTION
Scope.LookupParent takes additional argument(position parameter).

See also
- https://go.googlesource.com/tools/+/665374f1c86631cf73f4729095d4cf4313670545

This is related #22.