### PR TITLE
Add additional required parameter for `Scope.LookupParent()`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -243,7 +243,7 @@ func actionDoc(s *Session, in string) error {
 	} else if ident, ok := expr.(*ast.Ident); ok {
 		// package name
 		mainScope := s.TypeInfo.Scopes[s.mainFunc().Type]
-		_, docObj = mainScope.LookupParent(ident.Name)
+		_, docObj = mainScope.LookupParent(ident.Name, mainScope.Pos())
 	}
 
 	if docObj == nil {


### PR DESCRIPTION
This method now requires an additional parameter
See https://github.com/golang/tools/commit/665374f1c86631cf73f4729095d4cf4313670545#diff-d33fccaf6e5d3614051731c0beba520fR84