### PR TITLE
Add -pkg flag to specify the session's context package

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -70,3 +70,14 @@ func TestRun_FixImports(t *testing.T) {
 		noError(t, err)
 	}
 }
+
+func TestIncludePackage(t *testing.T) {
+	s, err := NewSession()
+	noError(t, err)
+
+	err = s.includePackage("github.com/motemen/gore/gocode")
+	noError(t, err)
+
+	err = s.Eval("Completer{}")
+	noError(t, err)
+}


### PR DESCRIPTION
Usage:

- `-pkg=<package path>`
- `-pkg=<directory>`

```
% gore -pkg=github.com/motemen/gore
gore version 0.1.0  :help for help
added file /Users/motemen/dev/go/src/github.com/motemen/gore/commands.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/complete.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/liner.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/log.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/main.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/node.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/quickfix.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/terminal_unix.go
added file /Users/motemen/dev/go/src/github.com/motemen/gore/utils.go
gore> version
"0.1.0"
```