### PR TITLE
add ":ssa" command to display intermediate representation of buffer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,6 +32,7 @@ Some functionalities are provided as colon-commands:
 
     :import <package path>  Import package
     :print                  Show current source
+    :ssa                    Show SSA IR representation of current source
     :write [<filename>]     Write out current source to file
     :doc <expr or pkg>      Show document (requires godoc)
     :help                   List commands

--- a/commands.go
+++ b/commands.go
@@ -48,6 +48,11 @@ func init() {
 			document: "print current source",
 		},
 		{
+			name:     "ssa",
+			action:   actionSSA,
+			document: "print the SSA representation of the current source",
+		},
+		{
 			name:     "write",
 			action:   actionWrite,
 			complete: nil, // TODO implement
@@ -177,6 +182,17 @@ func actionPrint(s *Session, _ string) error {
 
 	fmt.Println(source)
 
+	return nil
+}
+
+func actionSSA(s *Session, _ string) error {
+	source, err := s.dumpSSA()
+	if err != nil {
+		errorf("actionSSA: %v", err)
+		return err
+	}
+
+	fmt.Println(source)
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ import (
 	"github.com/motemen/go-quickfix"
 )
 
-const version = "0.2.5"
+const version = "0.2.6"
 const printerName = "__gore_p"
 
 var (

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ Some special functionalities are provided as commands, which starts with colons:
 
 	:import <package path>  Imports a package
 	:print                  Prints current source code
+	:ssa                    Prints the SSA IR for the current source code
 	:write [<filename>]     Writes out current code
 	:doc <target>           Shows documentation for an expression or package name given
 	:help                   Lists commands

--- a/ssa.go
+++ b/ssa.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+	"golang.org/x/tools/go/types"
+)
+
+func (s *Session) dumpSSA() (string, error) {
+	pkg := types.NewPackage("goresession", "")
+	if err := s.doQuickFix(); err != nil {
+		debugf("quickfix SSA: %v", err)
+		return "", nil
+	}
+	files := []*ast.File{s.File}
+	ssapkg, _, err := ssautil.BuildPackage(s.Types, s.Fset, pkg, files, ssa.SanityCheckFunctions)
+	if err != nil {
+		fmt.Print(err) // type error in some package
+		return "", err
+	}
+	var b bytes.Buffer
+	ssa.WriteFunction(&b, ssapkg.Func("main"))
+	debugf("ssa :: %s", b.String())
+	return b.String(), nil
+}


### PR DESCRIPTION
example of ":ssa" command output:

```
gore> foo := "foo"; bar := "bar"; baz := foo + bar + foo + bar;
"foobarfoobar"
gore> :import fmt
fmt.Print(baz)
foobarfoobar12
nil
```

```
gore> :ssa
# Name: goresession.main
# Package: goresession
# Location: gore_session.go:13:6
func main():
0:                                                                entry P:0 S:0
        t0 = "foo":string + "bar":string                                 string
        t1 = t0 + "foo":string                                           string
        t2 = t1 + "bar":string                                           string
        t3 = new [1]interface{} (varargs)                       *[1]interface{}
        t4 = &t3[0:int]                                            *interface{}
        t5 = make interface{} <- string (t2)                        interface{}
        *t4 = t5
        t6 = slice t3[:]                                          []interface{}
        t7 = fmt.Print(t6...)                                (n int, err error)
        return
```
