### PR TITLE
":print -ast" to show AST tree

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -45,6 +45,8 @@ func init() {
 		{
 			name:     "print",
 			action:   actionPrint,
+			complete: completePrint,
+			arg:      "[-ast]",
 			document: "print current source",
 		},
 		{
@@ -169,7 +171,15 @@ func completeDoc(s *Session, prefix string) []string {
 	return result
 }
 
-func actionPrint(s *Session, _ string) error {
+func completePrint(s *Session, prefix string) []string {
+	return []string{"-ast", ""}
+}
+
+func actionPrint(s *Session, mode string) error {
+	if mode == "-ast" {
+		return ast.Print(s.Fset, s.mainBody.List)
+	}
+
 	source, err := s.source(true)
 	if err != nil {
 		return err


### PR DESCRIPTION
```
gore> a := 1
1
gore> :print
package main

import "fmt"

func __gore_p(xx ...interface{}) {
    for _, x := range xx {
        fmt.Printf("%#v\n", x)
    }
}
func main() { a := 1 }

gore> :print -ast
     0  []ast.Stmt (len = 1) {
     1  .  0: *ast.AssignStmt {
     2  .  .  Lhs: []ast.Expr (len = 1) {
     3  .  .  .  0: *ast.Ident {
     4  .  .  .  .  NamePos: gore_session.go:10:15
     5  .  .  .  .  Name: "a"
     6  .  .  .  .  Obj: *ast.Object {
     7  .  .  .  .  .  Kind: var
     8  .  .  .  .  .  Name: "a"
     9  .  .  .  .  .  Decl: *(obj @ 1)
    10  .  .  .  .  }
    11  .  .  .  }
    12  .  .  }
    13  .  .  TokPos: gore_session.go:10:17
    14  .  .  Tok: :=
    15  .  .  Rhs: []ast.Expr (len = 1) {
    16  .  .  .  0: *ast.BasicLit {
    17  .  .  .  .  ValuePos: gore_session.go:10:20
    18  .  .  .  .  Kind: INT
    19  .  .  .  .  Value: "1"
    20  .  .  .  }
    21  .  .  }
    22  .  }
    23  }
```
