### PR TITLE
Fix unmatched braces issue

### DIFF
--- a/liner.go
+++ b/liner.go
@@ -68,9 +68,18 @@ func (cl *contLiner) Accepted() {
 	cl.buffer = ""
 }
 
-func (cl *contLiner) Reindent() {
+func (cl *contLiner) Clear() {
+	cl.buffer = ""
+	cl.depth = 0
+}
+
+func (cl *contLiner) Reindent() bool {
 	oldDepth := cl.depth
 	cl.depth = cl.countDepth()
+
+	if cl.depth < 0 {
+		return false
+	}
 
 	if cl.depth < oldDepth {
 		lines := strings.Split(cl.buffer, "\n")
@@ -83,6 +92,8 @@ func (cl *contLiner) Reindent() {
 			fmt.Print("\n")
 		}
 	}
+
+	return true
 }
 
 func (cl *contLiner) countDepth() int {

--- a/main.go
+++ b/main.go
@@ -116,7 +116,12 @@ func main() {
 			continue
 		}
 
-		rl.Reindent()
+		if !rl.Reindent() {
+			fmt.Fprintf(os.Stderr, "syntax error: unmatched braces\n")
+			rl.Clear()
+			continue
+		}
+
 		err = s.Eval(in)
 		if err != nil {
 			if err == ErrContinue {


### PR DESCRIPTION
The runtime error is raised if close braces are greater than open braces
(Then strings.Repeat(indent, negative_number) is called). This change
checks it and clears state if input is wrong.

This is related to #61.
CC: @willfaught

#### Original

```
% gore
gore version 0.2.5  :help for help
gore> if "a" == " {
panic: runtime error: makeslice: len out of range

goroutine 1 [running]:
strings.Repeat(0x762228, 0x4, 0xffffffffffffffff, 0x0, 0x0)
	/opt/go/src/strings/strings.go:464 +0x5f
main.(*contLiner).promptString(0xc820212140, 0x0, 0x0)
	/home/syohei/go/src/github.com/motemen/gore/liner.go:33 +0x54
main.(*contLiner).Reindent(0xc820212140)
	/home/syohei/go/src/github.com/motemen/gore/liner.go:81 +0xfc
main.main()
	/home/syohei/go/src/github.com/motemen/gore/main.go:119 +0xb16

goroutine 5 [syscall]:
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
	/usr/local/go/src/os/signal/signal_unix.go:28 +0x37

goroutine 6 [select, locked to thread]:
runtime.gopark(0x82bc40, 0xc820028728, 0x766110, 0x6, 0x43e618, 0x2)
	/opt/go/src/runtime/proc.go:185 +0x163
runtime.selectgoImpl(0xc820028728, 0x0, 0x18)
	/opt/go/src/runtime/select.go:392 +0xa64
runtime.selectgo(0xc820028728)
	/opt/go/src/runtime/select.go:212 +0x12
runtime.ensureSigM.func1()
	/opt/go/src/runtime/signal1_unix.go:227 +0x353
runtime.goexit()
	/opt/go/src/runtime/asm_amd64.s:1696 +0x1
```

#### Fixed version

```
% gore
gore version 0.2.5  :help for help
gore> if "a" == " {
..... }
syntax error: unmatched braces
gore>
```
