### PR TITLE
Fix for newer go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.4
   - 1.5
+  - 1.6
 install:
   - go get github.com/nsf/gocode
   - go get ./...

--- a/commands.go
+++ b/commands.go
@@ -14,8 +14,8 @@ import (
 
 	"go/ast"
 	"go/build"
+	"go/types"
 	"golang.org/x/tools/go/ast/astutil"
-	"golang.org/x/tools/go/types"
 )
 
 type command struct {
@@ -82,7 +82,7 @@ func actionImport(s *Session, arg string) error {
 	path := strings.Trim(arg, `"`)
 
 	// check if the package specified by path is importable
-	_, err := types.DefaultImport(s.Types.Packages, path)
+	_, err := s.Types.Importer.Import(path)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -31,13 +31,13 @@ import (
 
 	"go/ast"
 	"go/build"
+	"go/importer"
 	"go/parser"
 	"go/printer"
 	"go/scanner"
 	"go/token"
+	"go/types"
 
-	_ "golang.org/x/tools/go/gcimporter"
-	"golang.org/x/tools/go/types"
 	"golang.org/x/tools/imports"
 
 	"github.com/mitchellh/go-homedir"
@@ -207,7 +207,7 @@ func NewSession() (*Session, error) {
 	s := &Session{
 		Fset: token.NewFileSet(),
 		Types: &types.Config{
-			Packages: make(map[string]*types.Package),
+			Importer: importer.Default(),
 		},
 	}
 
@@ -218,7 +218,7 @@ func NewSession() (*Session, error) {
 
 	var initialSource string
 	for _, pp := range printerPkgs {
-		_, err := types.DefaultImport(s.Types.Packages, pp.path)
+		_, err := s.Types.Importer.Import(pp.path)
 		if err == nil {
 			initialSource = fmt.Sprintf(initialSourceTemplate, pp.path, pp.code)
 			break

--- a/quickfix.go
+++ b/quickfix.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 
 	"go/ast"
+	"go/types"
 	"golang.org/x/tools/go/ast/astutil"
-	"golang.org/x/tools/go/types"
 
 	"github.com/motemen/go-quickfix"
 )


### PR DESCRIPTION
This is similar to https://github.com/motemen/go-quickfix/pull/4 and related to #63.

However `TestNormalizeNodePos` in node_test.go is failed(with Go 1.6) which is not related to this PR. `go/printer.Fprint` sets needless indentations. I got following output.

```go
package P
		
		import "fmt"
		
		func F() {
			fmt.
				Println(
					1,
				)
		}
```

Expected result is here.

```go
package P

import "fmt"

func F() {
	fmt.
		Println(
		1,
	)
}
```
