### PR TITLE
Fix go-spew installation command in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ Make sure `$GOPATH/bin` is in your `$PATH`.
 Also recommended:
 
     go get -u github.com/nsf/gocode
-    go get -u github.com/k0kubun/pp # or github.com/davecgh/go-spew
+    go get -u github.com/k0kubun/pp # or github.com/davecgh/go-spew/spew
     go get -u golang.org/x/tools/cmd/godoc
 
 == FAQ/Caveats


### PR DESCRIPTION
Fixes the following issue trying to install `go-spew`:

```
$ go get -u github.com/davecgh/go-spew
package github.com/davecgh/go-spew: no Go files in /Users/user/Go/src/github.com/davecgh/go-spew
```