### PR TITLE
Fix error format

### DIFF
--- a/gocode/gocode_test.go
+++ b/gocode/gocode_test.go
@@ -9,7 +9,7 @@ import (
 func TestUnavailable(t *testing.T) {
 	c := &Completer{GocodePath: "./no-such-bin"}
 	if c.Available() {
-		t.Error("should not be available: %#v", c)
+		t.Errorf("should not be available: %#v", c)
 	}
 }
 


### PR DESCRIPTION
This fixes the error reported by Go 1.10 (that runs `go vet` with `go test`) on Travis:
```
$ go test ./...
# github.com/motemen/gore/gocode
gocode/gocode_test.go:12: Error call has possible formatting directive %#v
ok  	github.com/motemen/gore	5.837s
FAIL	github.com/motemen/gore/gocode [build failed]
```