### PR TITLE
[suggestion] output gore banner to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("gore version %s  :help for help\n", version)
+	fmt.Fprintf(os.Stderr, "gore version %s  :help for help\n", version)
 
 	if *flagExtFiles != "" {
 		extFiles := strings.Split(*flagExtFiles, ",")


### PR DESCRIPTION
So that the banner can be redirected to /dev/null for one-liners or script integration where we are interested in the actual output only. The banner should be used only for interactive mode. ;)