### PR TITLE
remove testing with go:tip on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
   - 1.x
-  - tip
 install:
   - go get github.com/nsf/gocode
   - go get ./...


### PR DESCRIPTION
Testing with go:tip takes 5 minutes while go:1.x finishes within 1 minute.