### PR TITLE
Fix :doc command in Go 1.12

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -288,12 +288,12 @@ func actionDoc(s *Session, in string) error {
 
 	debugf("doc :: %q %q", pkgPath, objName)
 
-	args := []string{pkgPath}
+	args := []string{"doc", pkgPath}
 	if objName != "" {
 		args = append(args, objName)
 	}
 
-	godoc := exec.Command("godoc", args...)
+	godoc := exec.Command("go", args...)
 	godoc.Stderr = s.stderr
 
 	// TODO just use PAGER?

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +10,6 @@ import (
 
 func TestActionDoc(t *testing.T) {
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	_, err := exec.LookPath("godoc")
-	if err != nil {
-		t.Skipf("godoc not found: %s", err)
-	}
 
 	s, err := NewSession(stdout, stderr)
 	defer s.Clear()


### PR DESCRIPTION
Go 1.12 removes support for `godoc` in favor of `go doc`.
See https://tip.golang.org/doc/go1.12#godoc for details

Tested in Go 1.12rc1 using the following `Dockerfile`:

```
# use stretch (as opposed to alpine) because we need to use CGO and so it's
# probably most meaningful to test against glibc (as opposed to musl)
FROM golang:rc-stretch

# build outside of GOPATH for default module behavior
WORKDIR /usr/local/src/gore
COPY . .

# lots and lots of output...
RUN go mod download > /dev/null 2>&1

CMD go test -v ./...
```

### Output

```
$ docker build -t gore:latest .
Sending build context to Docker daemon  10.99MB
Step 1/5 : FROM golang:rc-stretch
 ---> 553b7c7900d8
Step 2/5 : WORKDIR /usr/local/src/gore
 ---> Using cache
 ---> 64bcd9b4b26e
Step 3/5 : COPY . .
 ---> 5d4991b2da28
Step 4/5 : RUN go mod download > /dev/null 2>&1
 ---> Running in fb2c415d7ec0
Removing intermediate container fb2c415d7ec0
 ---> 2783783f1b4e
Step 5/5 : CMD go test -v ./...
 ---> Running in 2dde6b12fde9
Removing intermediate container 2dde6b12fde9
 ---> d24dc945980d
Successfully built d24dc945980d
Successfully tagged gore:latest

$ docker run --rm -it gore
=== RUN   TestActionDoc
--- PASS: TestActionDoc (1.27s)
=== RUN   TestActionImport
--- PASS: TestActionImport (0.56s)
=== RUN   TestSession_completeCode
--- SKIP: TestSession_completeCode (0.00s)
    complete_test.go:15: gocode unavailable
=== RUN   TestNormalizeNodePos
--- PASS: TestNormalizeNodePos (0.00s)
=== RUN   TestRun_import
--- PASS: TestRun_import (0.55s)
=== RUN   TestRun_QuickFix_evaluated_but_not_used
--- PASS: TestRun_QuickFix_evaluated_but_not_used (1.53s)
=== RUN   TestRun_QuickFix_used_as_value
--- PASS: TestRun_QuickFix_used_as_value (0.53s)
=== RUN   TestRun_FixImports
--- PASS: TestRun_FixImports (0.26s)
=== RUN   TestIncludePackage
added file /usr/local/src/gore/gocode/gocode.go
--- PASS: TestIncludePackage (0.40s)
=== RUN   TestRun_Copy
--- PASS: TestRun_Copy (1.02s)
=== RUN   TestRun_Const
--- PASS: TestRun_Const (0.76s)
=== RUN   TestRun_NotUsed
--- PASS: TestRun_NotUsed (2.32s)
=== RUN   TestRun_MultipleValues
--- PASS: TestRun_MultipleValues (2.37s)
=== RUN   TestRun_Error
--- PASS: TestRun_Error (0.25s)
PASS
ok  	github.com/motemen/gore	11.838s
=== RUN   TestUnavailable
--- PASS: TestUnavailable (0.00s)
=== RUN   TestQuery
--- SKIP: TestQuery (0.00s)
    gocode_test.go:18: gocode unavailable
PASS
ok  	github.com/motemen/gore/gocode	0.005s
```