### PR TITLE
Refactor commands

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -118,3 +118,19 @@ func TestAction_Quit(t *testing.T) {
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
+
+func TestAction_CommandNotFound(t *testing.T) {
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	s, err := NewSession(stdout, stderr)
+	defer s.Clear()
+	require.NoError(t, err)
+
+	err = s.Eval(":::")
+	require.NoError(t, err)
+
+	err = s.Eval(":foo")
+	require.Error(t, err)
+
+	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "command not found: foo\n", stderr.String())
+}

--- a/commands_test.go
+++ b/commands_test.go
@@ -105,3 +105,16 @@ func TestAction_Help(t *testing.T) {
 	assert.Contains(t, stdout.String(), "quit the session")
 	assert.Equal(t, "", stderr.String())
 }
+
+func TestAction_Quit(t *testing.T) {
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	s, err := NewSession(stdout, stderr)
+	defer s.Clear()
+	require.NoError(t, err)
+
+	err = s.Eval(":quit")
+	require.Equal(t, ErrQuit, err)
+
+	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "", stderr.String())
+}

--- a/commands_test.go
+++ b/commands_test.go
@@ -8,26 +8,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestActionDoc(t *testing.T) {
+func TestAction_Doc(t *testing.T) {
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-
 	s, err := NewSession(stdout, stderr)
 	defer s.Clear()
 	require.NoError(t, err)
 
-	err = actionImport(s, "encoding/json")
+	err = s.Eval(":import encoding/json")
 	require.NoError(t, err)
-	err = actionImport(s, "fmt")
+	err = s.Eval(":import fmt")
 	require.NoError(t, err)
 
 	test := func() {
-		err = actionDoc(s, "fmt")
+		err = s.Eval(":doc fmt")
 		require.NoError(t, err)
 
-		err = actionDoc(s, "fmt.Print")
+		err = s.Eval(":doc fmt.Print")
 		require.NoError(t, err)
 
-		err = actionDoc(s, "json.NewEncoder(nil).Encode")
+		err = s.Eval(":doc json.NewEncoder(nil).Encode")
 		require.NoError(t, err)
 	}
 
@@ -45,23 +44,27 @@ func TestActionDoc(t *testing.T) {
 	assert.Equal(t, "", stderr.String())
 }
 
-func TestActionImport(t *testing.T) {
+func TestAction_Import(t *testing.T) {
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	s, err := NewSession(stdout, stderr)
 	defer s.Clear()
 	require.NoError(t, err)
 
-	require.NoError(t, actionImport(s, "encoding/json fmt"))
+	err = s.Eval(":import encoding/json fmt")
+	require.NoError(t, err)
 
-	require.NoError(t, s.Eval("fmt.Print"))
-	require.NoError(t, s.Eval("json.Encoder{}"))
+	err = s.Eval("fmt.Print")
+	require.NoError(t, err)
+
+	err = s.Eval("json.Encoder{}")
+	require.NoError(t, err)
 
 	assert.Contains(t, stdout.String(), "(func(...interface {}) (int, error))")
 	assert.Contains(t, stdout.String(), "json.Encoder")
 	assert.Equal(t, "", stderr.String())
 }
 
-func TestActionClear(t *testing.T) {
+func TestAction_Clear(t *testing.T) {
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	s, err := NewSession(stdout, stderr)
 	defer s.Clear()

--- a/commands_test.go
+++ b/commands_test.go
@@ -91,3 +91,17 @@ func TestAction_Clear(t *testing.T) {
 `, stdout.String())
 	assert.Equal(t, "undefined: x\n", stderr.String())
 }
+
+func TestAction_Help(t *testing.T) {
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	s, err := NewSession(stdout, stderr)
+	defer s.Clear()
+	require.NoError(t, err)
+
+	err = s.Eval(":help")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout.String(), "show this help")
+	assert.Contains(t, stdout.String(), "quit the session")
+	assert.Equal(t, "", stderr.String())
+}

--- a/commands_test.go
+++ b/commands_test.go
@@ -98,7 +98,7 @@ func TestAction_Help(t *testing.T) {
 	defer s.Clear()
 	require.NoError(t, err)
 
-	err = s.Eval(":help")
+	err = s.Eval(": :  :   help  ")
 	require.NoError(t, err)
 
 	assert.Contains(t, stdout.String(), "show this help")
@@ -112,7 +112,7 @@ func TestAction_Quit(t *testing.T) {
 	defer s.Clear()
 	require.NoError(t, err)
 
-	err = s.Eval(":quit")
+	err = s.Eval(" :\t: quit")
 	require.Equal(t, ErrQuit, err)
 
 	assert.Equal(t, "", stdout.String())


### PR DESCRIPTION
- support spaces in the command prefix (ex: `: : :   help`)
- report command not found
- add more tests