### PR TITLE
Implement command abbreviation

### DIFF
--- a/command_name.go
+++ b/command_name.go
@@ -1,0 +1,56 @@
+package main
+
+import "strings"
+
+type commandName string
+
+func (s commandName) String() string {
+	var b strings.Builder
+	for _, c := range s {
+		if c != '[' && c != ']' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+func (s commandName) matches(t string) bool {
+	var grouping bool
+	for i, j := 0, 0; j <= len(t); i, j = i+1, j+1 {
+		if i >= len(s) {
+			return j == len(t)
+		}
+		if s[i] == '[' {
+			grouping = true
+			i++
+		}
+		if j == len(t) {
+			break
+		}
+		if s[i] == ']' {
+			return false
+		}
+		if s[i] != t[j] {
+			return false
+		}
+	}
+	return grouping
+}
+
+func (s commandName) matchesPrefix(t string) bool {
+	for i, j := 0, 0; j < len(t); i, j = i+1, j+1 {
+		if i >= len(s) {
+			return false
+		}
+		if s[i] == '[' {
+			i++
+		}
+		if s[i] == ']' {
+			return false
+		}
+		if s[i] != t[j] {
+			return false
+		}
+	}
+	return true
+}

--- a/commands.go
+++ b/commands.go
@@ -21,7 +21,7 @@ import (
 )
 
 type command struct {
-	name     string
+	name     commandName
 	action   func(*Session, string) error
 	complete func(*Session, string) []string
 	arg      string
@@ -37,43 +37,43 @@ var commands []command
 func init() {
 	commands = []command{
 		{
-			name:     "import",
+			name:     commandName("i[mport]"),
 			action:   actionImport,
 			complete: completeImport,
 			arg:      "<package>",
 			document: "import a package",
 		},
 		{
-			name:     "print",
+			name:     commandName("print"),
 			action:   actionPrint,
 			document: "print current source",
 		},
 		{
-			name:     "write",
+			name:     commandName("w[rite]"),
 			action:   actionWrite,
 			complete: nil, // TODO implement
 			arg:      "[<file>]",
 			document: "write out current source",
 		},
 		{
-			name:     "clear",
+			name:     commandName("clear"),
 			action:   actionClear,
 			document: "clear the codes",
 		},
 		{
-			name:     "doc",
+			name:     commandName("d[oc]"),
 			action:   actionDoc,
 			complete: completeDoc,
 			arg:      "<expr or pkg>",
 			document: "show documentation",
 		},
 		{
-			name:     "help",
+			name:     commandName("h[elp]"),
 			action:   actionHelp,
 			document: "show this help",
 		},
 		{
-			name:     "quit",
+			name:     commandName("q[uit]"),
 			action:   actionQuit,
 			document: "quit the session",
 		},
@@ -335,7 +335,7 @@ func actionDoc(s *Session, in string) error {
 func actionHelp(s *Session, _ string) error {
 	w := tabwriter.NewWriter(s.stdout, 0, 8, 4, ' ', 0)
 	for _, command := range commands {
-		cmd := ":" + command.name
+		cmd := fmt.Sprintf(":%s", command.name)
 		if command.arg != "" {
 			cmd = cmd + " " + command.arg
 		}

--- a/commands_test.go
+++ b/commands_test.go
@@ -16,7 +16,7 @@ func TestAction_Doc(t *testing.T) {
 
 	err = s.Eval(":import encoding/json")
 	require.NoError(t, err)
-	err = s.Eval(":import fmt")
+	err = s.Eval(":i fmt")
 	require.NoError(t, err)
 
 	test := func() {
@@ -26,7 +26,7 @@ func TestAction_Doc(t *testing.T) {
 		err = s.Eval(":doc fmt.Print")
 		require.NoError(t, err)
 
-		err = s.Eval(":doc json.NewEncoder(nil).Encode")
+		err = s.Eval(":d json.NewEncoder(nil).Encode")
 		require.NoError(t, err)
 	}
 
@@ -101,9 +101,14 @@ func TestAction_Help(t *testing.T) {
 	err = s.Eval(": :  :   help  ")
 	require.NoError(t, err)
 
+	assert.Contains(t, stdout.String(), ":import <package>")
+	assert.Contains(t, stdout.String(), ":write [<file>]")
 	assert.Contains(t, stdout.String(), "show this help")
 	assert.Contains(t, stdout.String(), "quit the session")
 	assert.Equal(t, "", stderr.String())
+
+	err = s.Eval(":h")
+	require.NoError(t, err)
 }
 
 func TestAction_Quit(t *testing.T) {
@@ -117,6 +122,9 @@ func TestAction_Quit(t *testing.T) {
 
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
+
+	err = s.Eval(":q")
+	require.Equal(t, ErrQuit, err)
 }
 
 func TestAction_CommandNotFound(t *testing.T) {
@@ -131,6 +139,19 @@ func TestAction_CommandNotFound(t *testing.T) {
 	err = s.Eval(":foo")
 	require.Error(t, err)
 
+	err = s.Eval(":ii")
+	require.Error(t, err)
+
+	err = s.Eval(":docc")
+	require.Error(t, err)
+
+	err = s.Eval(":help]")
+	require.Error(t, err)
+
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "command not found: foo\n", stderr.String())
+	assert.Equal(t, `command not found: foo
+command not found: ii
+command not found: docc
+command not found: help]
+`, stderr.String())
 }

--- a/complete.go
+++ b/complete.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 
@@ -27,8 +28,8 @@ func (s *Session) completeWord(line string, pos int) (string, []string, string) 
 			pre, post := line[:idx], line[pos:]
 			var result []string
 			for _, command := range commands {
-				name := pre + command.name
-				if cmd == "" || strings.HasPrefix(command.name, cmd) {
+				name := pre + fmt.Sprint(command.name)
+				if cmd == "" || command.name.matchesPrefix(cmd) {
 					if !strings.HasPrefix(post, " ") && command.arg != "" {
 						name = name + " "
 					}
@@ -40,7 +41,7 @@ func (s *Session) completeWord(line string, pos int) (string, []string, string) 
 
 		// complete command arguments
 		for _, command := range commands {
-			if command.complete == nil || command.name != cmd {
+			if command.complete == nil || !command.name.matches(cmd) {
 				continue
 			}
 			cmdPrefix := line[:idx] + cmd + " "

--- a/complete_test.go
+++ b/complete_test.go
@@ -40,6 +40,16 @@ func TestSession_completeWord(t *testing.T) {
 	assert.Equal(t, []string{" : : import "}, cands)
 	assert.Equal(t, post, "")
 
+	pre, cands, post = s.completeWord("::i t", 5)
+	assert.Equal(t, "::i ", pre)
+	assert.Equal(t, []string{"testing", "text", "time"}, cands)
+	assert.Equal(t, post, "")
+
+	pre, cands, post = s.completeWord(":c", 2)
+	assert.Equal(t, "", pre)
+	assert.Equal(t, []string{":clear"}, cands)
+	assert.Equal(t, post, "")
+
 	pre, cands, post = s.completeWord(" : : q", 6)
 	assert.Equal(t, "", pre)
 	assert.Equal(t, []string{" : : quit"}, cands)

--- a/session.go
+++ b/session.go
@@ -378,7 +378,7 @@ func (s *Session) invokeCommand(in string) (err error) {
 	cmd := tokens[0]
 	arg := strings.TrimSpace(strings.TrimPrefix(in, cmd))
 	for _, command := range commands {
-		if command.name != cmd {
+		if !command.name.matches(cmd) {
 			continue
 		}
 		err = command.action(s, arg)


### PR DESCRIPTION
Like Vim, implemented command abbreviations.
```go
~/.go/src/github.com/motemen/gore gore
gore version 0.3.0  :help for help
gore> :i fmt
gore> :w
Source wrote to gore_session_20190224_015549.go
gore> :h
    :import <package>     import a package
    :print                print current source
    :write [<file>]       write out current source
    :clear                clear the codes
    :doc <expr or pkg>    show documentation
    :help                 show this help
    :quit                 quit the session
gore> :q
~/.go/src/github.com/motemen/gore
```