### PR TITLE
Improve gocode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - 1.x
 install:
   - make build
-  - go get github.com/nsf/gocode
+  - go get github.com/mdempsky/gocode
 script:
   - make lint
   - make test

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ To quit the session, type `Ctrl-D`.
 * Package importing with completion
 * Evaluates any expressions or statements
 * No "evaluated but not used"
-* Code completion (requires https://github.com/nsf/gocode[gocode])
+* Code completion (requires https://github.com/mdempsky/gocode[gocode])
 * Pretty printing (https://github.com/k0kubun/pp[pp] or https://github.com/davecgh/go-spew[spew] recommended)
 * Showing documents (requires https://golang.org/x/tools/cmd/godoc[godoc])
 * Auto-importing
@@ -47,7 +47,7 @@ Make sure `$GOPATH/bin` is in your `$PATH`.
 
 Also recommended:
 
-    go get -u github.com/nsf/gocode # for code completion
+    go get -u github.com/mdempsky/gocode # for code completion
     go get -u github.com/k0kubun/pp # or github.com/davecgh/go-spew/spew
     go get -u golang.org/x/tools/cmd/godoc # for using with the :doc colon-command
 

--- a/complete.go
+++ b/complete.go
@@ -69,7 +69,7 @@ func (s *Session) completeWord(line string, pos int) (string, []string, string) 
 	return line[0:pos], cands, ""
 }
 
-// completeCode does code completion within the session using gocode (https://github.com/nsf/gocode).
+// completeCode does code completion within the session using gocode.
 // in and pos specifies the current input and the cursor position (0 <= pos <= len(in)) respectively.
 // If exprMode is set to true, the completion is done as an expression (e.g. appends "(" to functions).
 // Return value keep specifies how many characters of in should be kept and candidates are what follow in[0:keep].

--- a/gocode/gocode.go
+++ b/gocode/gocode.go
@@ -1,6 +1,7 @@
 package gocode
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -67,7 +68,7 @@ func (c *Completer) Query(source []byte, cursor int) (*Result, error) {
 			// cannot invoke gocode
 			c.unavailable = true
 		}
-		return nil, err
+		return nil, fmt.Errorf("%s: %s", string(bytes.TrimSpace(out)), err)
 	}
 
 	var result Result

--- a/gocode/gocode.go
+++ b/gocode/gocode.go
@@ -1,4 +1,3 @@
-// Package gocode is an interface to github.com/nsf/gocode.
 package gocode
 
 import (


### PR DESCRIPTION
nsf/gocode is deprecated in favor of mdempsky/gocode.