### PR TITLE
Create cli package and make gore usable from another package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN := gore
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
-BUILD_LDFLAGS := "-s -w -X github.com/motemen/gore.revision=$(CURRENT_REVISION)"
+BUILD_LDFLAGS := "-s -w -X github.com/motemen/$(BIN)/cli.revision=$(CURRENT_REVISION)"
 
 .PHONY: all
 all: clean build

--- a/cli.go
+++ b/cli.go
@@ -24,7 +24,6 @@ func (c *cli) run(args []string) error {
 }
 
 func (c *cli) parseArgs(args []string) (*Gore, error) {
-	g := &Gore{outWriter: c.outWriter, errWriter: c.errWriter}
 	fs := flag.NewFlagSet("gore", flag.ContinueOnError)
 	fs.SetOutput(c.errWriter)
 	fs.Usage = func() {
@@ -42,9 +41,14 @@ Options:
 		fs.PrintDefaults()
 	}
 
-	fs.BoolVar(&g.autoImport, "autoimport", false, "formats and adjusts imports automatically")
-	fs.StringVar(&g.extFiles, "context", "", "import packages, functions, variables and constants from external golang source files")
-	fs.StringVar(&g.packageName, "pkg", "", "the package where the session will be run inside")
+	var autoImport bool
+	fs.BoolVar(&autoImport, "autoimport", false, "formats and adjusts imports automatically")
+
+	var extFiles string
+	fs.StringVar(&extFiles, "context", "", "import packages, functions, variables and constants from external golang source files")
+
+	var packageName string
+	fs.StringVar(&packageName, "pkg", "", "the package where the session will be run inside")
 
 	var showVersion bool
 	fs.BoolVar(&showVersion, "version", false, "print gore version")
@@ -59,5 +63,11 @@ Options:
 		return nil, flag.ErrHelp
 	}
 
-	return g, nil
+	return New(
+		AutoImport(autoImport),
+		ExtFiles(extFiles),
+		PackageName(packageName),
+		OutWriter(c.outWriter),
+		ErrWriter(c.errWriter),
+	), nil
 }

--- a/cli.go
+++ b/cli.go
@@ -16,15 +16,15 @@ func (c *cli) run(args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := g.run(); err != nil {
+	if err := g.Run(); err != nil {
 		fmt.Fprintf(c.errWriter, "gore: %s\n", err)
 		return err
 	}
 	return nil
 }
 
-func (c *cli) parseArgs(args []string) (*gore, error) {
-	g := &gore{outWriter: c.outWriter, errWriter: c.errWriter}
+func (c *cli) parseArgs(args []string) (*Gore, error) {
+	g := &Gore{outWriter: c.outWriter, errWriter: c.errWriter}
 	fs := flag.NewFlagSet("gore", flag.ContinueOnError)
 	fs.SetOutput(c.errWriter)
 	fs.Usage = func() {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,11 +1,15 @@
-package gore
+package cli
 
 import (
 	"flag"
 	"fmt"
 	"io"
 	"runtime"
+
+	"github.com/motemen/gore"
 )
+
+var revision = "HEAD"
 
 type cli struct {
 	outWriter, errWriter io.Writer
@@ -23,7 +27,7 @@ func (c *cli) run(args []string) error {
 	return nil
 }
 
-func (c *cli) parseArgs(args []string) (*Gore, error) {
+func (c *cli) parseArgs(args []string) (*gore.Gore, error) {
 	fs := flag.NewFlagSet("gore", flag.ContinueOnError)
 	fs.SetOutput(c.errWriter)
 	fs.Usage = func() {
@@ -37,7 +41,7 @@ Synopsis:
     %% gore
 
 Options:
-`, version, revision, runtime.Version())
+`, gore.Version, revision, runtime.Version())
 		fs.PrintDefaults()
 	}
 
@@ -59,15 +63,15 @@ Options:
 	}
 
 	if showVersion {
-		fmt.Fprintf(c.outWriter, "gore %s (rev: %s/%s)\n", version, revision, runtime.Version())
+		fmt.Fprintf(c.outWriter, "gore %s (rev: %s/%s)\n", gore.Version, revision, runtime.Version())
 		return nil, flag.ErrHelp
 	}
 
-	return New(
-		AutoImport(autoImport),
-		ExtFiles(extFiles),
-		PackageName(packageName),
-		OutWriter(c.outWriter),
-		ErrWriter(c.errWriter),
+	return gore.New(
+		gore.AutoImport(autoImport),
+		gore.ExtFiles(extFiles),
+		gore.PackageName(packageName),
+		gore.OutWriter(c.outWriter),
+		gore.ErrWriter(c.errWriter),
 	), nil
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,20 +11,28 @@ import (
 
 var revision = "HEAD"
 
+const (
+	exitCodeOK = iota
+	exitCodeErr
+)
+
 type cli struct {
 	outWriter, errWriter io.Writer
 }
 
-func (c *cli) run(args []string) error {
+func (c *cli) run(args []string) int {
 	g, err := c.parseArgs(args)
 	if err != nil {
-		return err
+		if err != flag.ErrHelp {
+			return exitCodeErr
+		}
+		return exitCodeOK
 	}
 	if err := g.Run(); err != nil {
 		fmt.Fprintf(c.errWriter, "gore: %s\n", err)
-		return err
+		return exitCodeErr
 	}
-	return nil
+	return exitCodeOK
 }
 
 func (c *cli) parseArgs(args []string) (*gore.Gore, error) {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,8 +13,8 @@ import (
 func TestCliRun_Version(t *testing.T) {
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	c := &cli{stdout, stderr}
-	err := c.run([]string{"-version"})
-	require.Equal(t, err, flag.ErrHelp)
+	code := c.run([]string{"-version"})
+	require.Equal(t, exitCodeOK, code)
 
 	assert.Contains(t, stdout.String(), "gore "+gore.Version)
 	assert.Equal(t, "", stderr.String())
@@ -24,8 +23,8 @@ func TestCliRun_Version(t *testing.T) {
 func TestCliRun_Help(t *testing.T) {
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	c := &cli{stdout, stderr}
-	err := c.run([]string{"-help"})
-	require.Equal(t, err, flag.ErrHelp)
+	code := c.run([]string{"-help"})
+	require.Equal(t, exitCodeOK, code)
 
 	assert.Contains(t, stdout.String(), "gore -")
 	assert.Contains(t, stdout.String(), "Options:")
@@ -35,8 +34,8 @@ func TestCliRun_Help(t *testing.T) {
 func TestCliRun_Unknown(t *testing.T) {
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
 	c := &cli{stdout, stderr}
-	err := c.run([]string{"-foobar"})
-	require.Error(t, err)
+	code := c.run([]string{"-foobar"})
+	require.Equal(t, exitCodeErr, code)
 
 	assert.Contains(t, stdout.String(), "gore -")
 	assert.Contains(t, stderr.String(), "flag provided but not defined: -foobar")

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,4 +1,4 @@
-package gore
+package cli
 
 import (
 	"bytes"
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/motemen/gore"
 )
 
 func TestCliRun_Version(t *testing.T) {
@@ -15,7 +17,7 @@ func TestCliRun_Version(t *testing.T) {
 	err := c.run([]string{"-version"})
 	require.Equal(t, err, flag.ErrHelp)
 
-	assert.Contains(t, stdout.String(), "gore "+version)
+	assert.Contains(t, stdout.String(), "gore "+gore.Version)
 	assert.Equal(t, "", stderr.String())
 }
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -1,4 +1,4 @@
-package gore
+package cli
 
 import (
 	"flag"

--- a/cli/run.go
+++ b/cli/run.go
@@ -3,9 +3,9 @@ package cli
 import "os"
 
 // Run gore.
-func Run(args []string) int {
+func Run() int {
 	return (&cli{
 		outWriter: os.Stdout,
 		errWriter: os.Stderr,
-	}).run(args)
+	}).run(os.Args[1:])
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -1,18 +1,11 @@
 package cli
 
-import (
-	"flag"
-	"os"
-)
+import "os"
 
 // Run gore.
-func Run(args []string) error {
-	err := (&cli{outWriter: os.Stdout, errWriter: os.Stderr}).run(args)
-	if err != nil {
-		if err == flag.ErrHelp {
-			return nil
-		}
-		return err
-	}
-	return nil
+func Run(args []string) int {
+	return (&cli{
+		outWriter: os.Stdout,
+		errWriter: os.Stderr,
+	}).run(args)
 }

--- a/cmd/gore/main.go
+++ b/cmd/gore/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"os"
 
-	"github.com/motemen/gore"
+	"github.com/motemen/gore/cli"
 )
 
 func main() {
-	if gore.Run(os.Args[1:]) != nil {
+	if cli.Run(os.Args[1:]) != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/gore/main.go
+++ b/cmd/gore/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	os.Exit(cli.Run(os.Args[1:]))
+	os.Exit(cli.Run())
 }

--- a/cmd/gore/main.go
+++ b/cmd/gore/main.go
@@ -7,7 +7,5 @@ import (
 )
 
 func main() {
-	if cli.Run(os.Args[1:]) != nil {
-		os.Exit(1)
-	}
+	os.Exit(cli.Run(os.Args[1:]))
 }

--- a/gore.go
+++ b/gore.go
@@ -18,6 +18,15 @@ type Gore struct {
 	outWriter, errWriter io.Writer
 }
 
+// New Gore
+func New(opts ...Option) *Gore {
+	g := &Gore{outWriter: os.Stdout, errWriter: os.Stderr}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g
+}
+
 // Run ...
 func (g *Gore) Run() error {
 	s, err := NewSession(g.outWriter, g.errWriter)

--- a/gore.go
+++ b/gore.go
@@ -10,14 +10,16 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-type gore struct {
+// Gore ...
+type Gore struct {
 	autoImport           bool
 	extFiles             string
 	packageName          string
 	outWriter, errWriter io.Writer
 }
 
-func (g *gore) run() error {
+// Run ...
+func (g *Gore) Run() error {
 	s, err := NewSession(g.outWriter, g.errWriter)
 	defer s.Clear()
 	if err != nil {

--- a/gore.go
+++ b/gore.go
@@ -10,6 +10,9 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
+// Version of gore.
+const Version = "0.4.0"
+
 // Gore ...
 type Gore struct {
 	autoImport           bool
@@ -36,7 +39,7 @@ func (g *Gore) Run() error {
 	}
 	s.autoImport = g.autoImport
 
-	fmt.Fprintf(g.errWriter, "gore version %s  :help for help\n", version)
+	fmt.Fprintf(g.errWriter, "gore version %s  :help for help\n", Version)
 
 	if g.extFiles != "" {
 		extFiles := strings.Split(g.extFiles, ",")

--- a/option.go
+++ b/option.go
@@ -1,0 +1,41 @@
+package gore
+
+import "io"
+
+// Option for Gore
+type Option func(*Gore)
+
+// AutoImport option
+func AutoImport(autoImport bool) Option {
+	return func(g *Gore) {
+		g.autoImport = autoImport
+	}
+}
+
+// ExtFiles option
+func ExtFiles(extFiles string) Option {
+	return func(g *Gore) {
+		g.extFiles = extFiles
+	}
+}
+
+// PackageName option
+func PackageName(packageName string) Option {
+	return func(g *Gore) {
+		g.packageName = packageName
+	}
+}
+
+// OutWriter option
+func OutWriter(outWriter io.Writer) Option {
+	return func(g *Gore) {
+		g.outWriter = outWriter
+	}
+}
+
+// ErrWriter option
+func ErrWriter(errWriter io.Writer) Option {
+	return func(g *Gore) {
+		g.errWriter = errWriter
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,5 +1,0 @@
-package gore
-
-const version = "0.4.0"
-
-var revision = "HEAD"


### PR DESCRIPTION
This is related to  #131 but make gore possible to use from another package. I created cli package and moved args parsing to it. Users can initialize Gore struct with functional options and call Run.
Related issues: #4, #14, #74, #79, #131.