### PR TITLE
Change the directory of go run to the temporary directory

### DIFF
--- a/session.go
+++ b/session.go
@@ -150,6 +150,7 @@ func (s *Session) goRun(files []string) error {
 	cmd := exec.Command("go", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = s.stdout
+	cmd.Dir = s.tempDir
 	ef := newErrFilter(s.stderr)
 	cmd.Stderr = ef
 	defer ef.Close()


### PR DESCRIPTION
This is a simple solution not to overwrite go module files (ref: #143).