### PR TITLE
set the directory to the temporary directory on :doc command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -346,6 +346,7 @@ func actionDoc(s *Session, in string) error {
 	}
 
 	godoc := exec.Command("go", args...)
+	godoc.Dir = s.tempDir
 	godoc.Stderr = s.stderr
 
 	// TODO just use PAGER?

--- a/commands.go
+++ b/commands.go
@@ -347,7 +347,10 @@ func actionDoc(s *Session, in string) error {
 
 	godoc := exec.Command("go", args...)
 	godoc.Dir = s.tempDir
-	godoc.Stderr = s.stderr
+	godoc.Env = append(os.Environ(), "GO111MODULE=on")
+	ef := newErrFilter(s.stderr)
+	godoc.Stderr = ef
+	defer ef.Close()
 
 	// TODO just use PAGER?
 	if pagerCmd := os.Getenv("GORE_PAGER"); pagerCmd != "" {

--- a/errfilter.go
+++ b/errfilter.go
@@ -47,6 +47,9 @@ func replaceErrMsg(p []byte) []byte {
 	if bytes.HasPrefix(p, []byte("# command-line-arguments")) {
 		return nil
 	}
+	if bytes.HasPrefix(p, []byte(`warning: pattern "all" matched no module dependencies`)) {
+		return nil
+	}
 	if i := bytes.Index(p, []byte("gore_session.go")); i >= 0 {
 		if j := bytes.IndexRune(p[i:], ' '); j >= 0 {
 			return p[i+j+1:]

--- a/errfilter_test.go
+++ b/errfilter_test.go
@@ -36,6 +36,11 @@ func TestErrFilter(t *testing.T) {
 			"# command-line-arguments foo\n/tmp/gore_session.go:10:24: undefined: foo",
 			"undefined: foo",
 		},
+		{
+			"no module dependencies warning",
+			"warning: pattern \"all\" matched no module dependencies\nwarning: pattern \"all\" matched no module dependencie",
+			"warning: pattern \"all\" matched no module dependencie",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.id, func(t *testing.T) {


### PR DESCRIPTION
This pull request changes the directory of go doc to the temporary directory. Also ignores a warning to make the tests pass. I can't understand why `GO111MODULE=on go doc strings.Join` at home directory emits a warning to stderr.