### PR TITLE
do not disable Go Modules on getting Go tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: $(GOBIN)/golint
 	golint -set_exit_status ./...
 
 $(GOBIN)/golint:
-	GO111MODULE=off go get golang.org/x/lint/golint
+	cd && go get golang.org/x/lint/golint
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Some functionalities are provided as commands in the REPL:
 The gore command requires Go tool-chains on runtime, so standalone binary is not distributed.
 
 ```sh
-GO111MODULE=off go get -u github.com/motemen/gore/cmd/gore
+go get -u github.com/motemen/gore/cmd/gore
 ```
 
 Make sure `$GOPATH/bin` is in your `$PATH`.
@@ -55,8 +55,8 @@ Make sure `$GOPATH/bin` is in your `$PATH`.
 Also recommended:
 
 ```sh
-GO111MODULE=off go get -u github.com/mdempsky/gocode   # for code completion
-GO111MODULE=off go get -u github.com/k0kubun/pp        # or github.com/davecgh/go-spew/spew
+go get -u github.com/mdempsky/gocode   # for code completion
+go get -u github.com/k0kubun/pp        # or github.com/davecgh/go-spew/spew
 ```
 
 ## FAQ/Caveats


### PR DESCRIPTION
When a tool is expected to be built with modules on, it is not good to forcibly disable the modules.