### PR TITLE
ensure make clean removes the executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ $(GOBIN)/golint:
 
 .PHONY: clean
 clean:
-	rm -rf build
+	rm -f $(BIN)
 	go clean


### PR DESCRIPTION
catch up for #162 