### PR TITLE
Add supported version to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Some functionalities are provided as commands in the REPL:
 ```
 
 ## Supported Versions
-go1.12 or later.
+Only the latest major version.
 
 ## Installation
 The gore command requires Go tool-chains on runtime, so standalone binary is not distributed.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Some functionalities are provided as commands in the REPL:
 :quit                   Quit the session
 ```
 
-## Installation
+## Supported Versions
+go1.12 or later.
 
+## Installation
 The gore command requires Go tool-chains on runtime, so standalone binary is not distributed.
 
 ```sh


### PR DESCRIPTION
### Environment
`go version go1.11.1 darwin/amd64`

### What I did
An error occurred caused by commands below.
```
$  go get -u github.com/motemen/gore/cmd/gore

# github.com/motemen/gore
go/1.11.1/src/github.com/motemen/gore/gore.go:142:14: undefined: os.UserHomeDir
```

**On go1.12, the installation succeeded.**

UserHomeDir is only available go1.12 or later.

https://github.com/motemen/gore/blob/d2d6a78129f3580de982be30d36e341161b04e58/gore.go#L142

c.f.  https://golang.org/doc/go1.12#os

### Conclusion
I would like to add the supported version to README.md.

 