### PR TITLE
Update Dockerfile: build using the local code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM golang:1.14.1-alpine3.11
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git make
+WORKDIR /go/src/github.com/motemen/gore/
+COPY . .
+RUN make install
+
 RUN go get -u github.com/mdempsky/gocode   # for code completion
-RUN go get -u github.com/motemen/gore/cmd/gore
 
 ENTRYPOINT ["gore"]


### PR DESCRIPTION
Follow up of #186. Using `make` fills the revision with `-version` flag.