### PR TITLE
fix -autoimport flag by go get -d modules for Go 1.16

### DIFF
--- a/gomod.go
+++ b/gomod.go
@@ -19,12 +19,12 @@ import (
 func (s *Session) initGoMod() error {
 	tempModule := filepath.Base(s.tempDir)
 	goModPath := filepath.Join(s.tempDir, "go.mod")
-	directives := listModuleDirectives()
+	directives := s.listModuleDirectives()
 	mod := "module " + tempModule + "\n" + strings.Join(directives, "\n")
 	return ioutil.WriteFile(goModPath, []byte(mod), 0644)
 }
 
-func listModuleDirectives() []string {
+func (s *Session) listModuleDirectives() []string {
 	var directives []string
 	for i, pp := range printerPkgs {
 		if pp.path == "fmt" {
@@ -62,6 +62,7 @@ func listModuleDirectives() []string {
 	for _, m := range modules {
 		if m.Main || m.Replace != nil {
 			directives = append(directives, "replace "+m.Path+" => "+strconv.Quote(m.Dir))
+			s.requiredModules = append(s.requiredModules, m.Path)
 		}
 	}
 	return directives

--- a/session_gomod_test.go
+++ b/session_gomod_test.go
@@ -203,11 +203,3 @@ func TestSessionEval_Gomod_CompleteImport(t *testing.T) {
 	assert.Subset(t, cands, []string{"mod2/mod3", "mod2/mod4"})
 	assert.Equal(t, post, "")
 }
-
-func TestGetCurrentModule(t *testing.T) {
-	directives := listModuleDirectives()
-	pwd, _ := os.Getwd()
-	assert.Equal(t, []string{
-		"replace github.com/motemen/gore => " + strconv.Quote(pwd),
-	}, directives)
-}


### PR DESCRIPTION
This is required since Go 1.16.